### PR TITLE
feat: add PHP zip and xdebug extensions to WP container

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "hostname": "0.0.0.0",
+            "pathMappings": {
+                "/var/www/html": "${workspaceFolder}"
+            },
+            "stopOnEntry": true
+        }
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,30 @@ FROM php:8.1.4-fpm-alpine
 
 ENV PATH "$PATH:/var/www/html/vendor/bin"
 
-ENV PHP_GD_DEPS "freetype-dev libjpeg-turbo-dev libpng-dev"
+ENV PHP_GD_DEPS "freetype-dev libjpeg-turbo-dev libpng-dev libzip libzip-dev"
 
 # Set up PHP with modules and ini settings for running WordPress
 RUN apk update \
     && apk add --no-cache $PHP_GD_DEPS \
-    && docker-php-ext-install gd mysqli pdo pdo_mysql \
+    && docker-php-ext-install gd mysqli pdo pdo_mysql zip \
     && echo "date.timezone=Europe/London" > /usr/local/etc/php/conf.d/zz-custom.ini \
     && echo "session.autostart=0" >> /usr/local/etc/php/conf.d/zz-custom.ini
 
 RUN apk update && apk add --virtual --no-cache \
-    imagemagick imagemagick-dev $PHPIZE_DEPS \
+    imagemagick imagemagick-dev linux-headers $PHPIZE_DEPS \
     && pecl install imagick \
-    && docker-php-ext-enable imagick \
-    && apk del imagemagick-dev $PHPIZE_DEPS
+    && pecl install xdebug \
+    && docker-php-ext-enable imagick xdebug \
+    && apk del imagemagick-dev linux-headers $PHPIZE_DEPS
+
+RUN { \
+    echo "zend_extension=xdebug"; \
+    echo "xdebug.mode=develop,debug"; \
+    echo "xdebug.start_with_request=yes"; \
+    echo "xdebug.client_host=host.docker.internal"; \
+    echo "xdebug.idekey=VSCODE"; \
+    echo "xdebug.log=/tmp/xdebug_remote.log"; \
+} > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini;
 
 # Install wp-cli
 RUN curl -o /bin/wp-cli.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - WORDPRESS_DB_PASSWORD=password
     depends_on:
       - mysql
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: always
 
   composer:


### PR DESCRIPTION
## Description
Adds packages, PHP extensions and config required to use the PHP zip and xdebug extensions.

## Motivation and Context
ZIP: Required to export theme from WordPress.
XDebug: Generally useful for debugging.

## How Can It Be Tested?
- Create a block theme in WordPress then try to export it. A zip file should be downloaded.
- Open the project in VSCode, run "Listen to XDebug", then start the containers with `docker compose up` and visit localhost:8082. The code execution should pause on the first line of web/index.php.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- * I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.
- * My change requires a change to the documentation.
- * I've updated the documentation accordingly.
- * Replace unused checkboxes with bullet points.