### PR TITLE
feat: enable FILE_EDIT in development

### DIFF
--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -17,4 +17,5 @@ Config::define('DISALLOW_INDEXING', true);
 ini_set('display_errors', '1');
 
 // Enable plugin and theme updates and installation from the admin
+Config::define('DISALLOW_FILE_EDIT', false);
 Config::define('DISALLOW_FILE_MODS', false);


### PR DESCRIPTION
This is to allow the create-block-theme plugin to install fonts.