### PR TITLE
fix: use relative redirects in nginx to fix bad redirect URLs

### DIFF
--- a/docker/nginx/config/wordpress.conf
+++ b/docker/nginx/config/wordpress.conf
@@ -9,6 +9,9 @@ server {
 
     root /var/www/html/web;
 
+    # Use relative redirects so the port in the URL isn't changed
+    absolute_redirect off;
+
     location / {
         try_files $uri $uri/ /index.php$is_args$args;
     }


### PR DESCRIPTION
nginx will remove the port when a request is made to a folder (e.g. localhost:8082/wp -> localhost/wp/).
This change makes nginx use relative redirects (e.g. /wp -> /wp/), fixing the issue.