### PR TITLE
fix: bump php fpm docker base to fix xdebug-related segfault

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1.4-fpm-alpine
+FROM php:8.1.27-fpm-alpine
 
 ENV PATH "$PATH:/var/www/html/vendor/bin"
 


### PR DESCRIPTION
Noticed while working on the LRU project that PHP-FPM would segfault occasionally when using the xdebug debugger. Bumping the version fixes the issue.