### PR TITLE
Add plugin script that prevents activation of WordFence in development

### DIFF
--- a/web/app/mu-plugins/deactivate-wordfence-in-development.php
+++ b/web/app/mu-plugins/deactivate-wordfence-in-development.php
@@ -1,0 +1,38 @@
+<?php
+/*
+Plugin Name:  Deactivate WordFence Plugin in Development
+Description:  Disallow activation of WordFence in Development environments
+Version:      1.0.0
+Author:       Common Knowledge
+Author URI:   https://commonknowledge.coop/
+Text Domain:  commonknowledge
+License:      MIT License
+*/
+
+
+add_action('admin_init', function () {
+    if (defined('WP_ENV') && WP_ENV === 'development') {
+        include_once(ABSPATH . 'wp-admin/includes/plugin.php');
+
+         // Add an admin notice to explain why WordFence is not activated
+        add_action('admin_notices', function () {
+            echo '<div class="notice notice-warning"><p>Wordfence has been automatically deactivated because this is a development environment.</p></div>';
+        });
+   
+        // Deactivate Wordfence plugin if it's active
+        if (is_plugin_active('wordfence/wordfence.php')) {
+            deactivate_plugins('wordfence/wordfence.php');
+        }
+    }
+});
+
+// Prevent activation of Wordfence in development environment
+add_filter('plugin_action_links', function ($actions, $plugin_file, $plugin_data, $context) {
+    if (defined('WP_ENV') && WP_ENV === 'development' && $plugin_file == 'wordfence/wordfence.php') {
+        if (isset($actions['activate'])) {
+            unset($actions['activate']);
+            $actions['cannot_activate'] = 'Cannot activate in development environment.';
+        }
+    }
+    return $actions;
+}, 10, 4);


### PR DESCRIPTION

## Description
This PR adds a must use plugin that prevents the activation of WordFence in dev environments and displays a message.
N.B it doesn't prevent activation by WP CLI - only in the admin dashboard

## Motivation and Context
Addresses issue [CK-2386](https://linear.app/commonknowledge/issue/CK-2386/prevent-activation-of-wordfence-on-dev-environments)

## How Can It Be Tested?
Download the branch and run locally. Go to plugins dashboard. Observe that the plugin is deactivated.

## How Will This Be Deployed?
Normal deployment process

## Screenshots (if appropriate):
![Untitled1](https://github.com/commonknowledge/wordpress-starter-template/assets/43313455/3d5897e6-503b-4dc3-afa3-ff0d59888cc3)

